### PR TITLE
just fixing the playbook example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can see example of playbook in playbook_example/config.yml
 
 * Run the playbook, see README of example playbook
 
-[playbook readme](./playbook_example/README.rst)
+[playbook readme](./playbook_example/README.md)
 
 
 License


### PR DESCRIPTION
The playbook example link in the main README was outdated, pointing it to the right target, nothing else. 