### PR TITLE
Adding meta file so that this role can be installed by Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  role_name: redhat_satellite6_installation
+  author: Julio Villarreal Pelegrino julio@linux.com
+  description: This role installs Red Hat Satellite 6
+  company: Red Hat
+  license: GPLv3
+  min_ansible_version: 2.4
+  platforms:
+    - name: EL
+      versions:
+        - 7
+  galaxy_tags:
+    - satellite
+    - content
+    - system
+    - redhat
+
+dependencies: []


### PR DESCRIPTION
In order to be able to use this role in a Ansible Galaxy requirements file, it needs a meta file. Accept mine or please add one with the correct values. Thanks.